### PR TITLE
Improve responsive layout for mobile use

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>ÑandeBaby Timer</title>
   </head>
-  <body>
+  <body class="min-h-screen">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -101,7 +101,7 @@ function useLocalStorage(key, initial) {
     } catch { return initial; }
   });
   useEffect(() => {
-    try { localStorage.setItem(key, JSON.stringify(value)); } catch {}
+    try { localStorage.setItem(key, JSON.stringify(value)); } catch { /* ignore */ }
   }, [key, value]);
   return [value, setValue];
 }
@@ -197,7 +197,7 @@ export default function App(){
         return merged.sort((a,b)=> new Date(b.time)-new Date(a.time));
       });
       alert("Importación completada");
-    } catch (e){
+    } catch {
       alert("No se pudo importar el CSV");
     } finally { if (fileInputRef.current) fileInputRef.current.value = ""; }
   }
@@ -228,7 +228,6 @@ export default function App(){
     expect('diffToCountdown shows 00:01:', diffToCountdown(future).startsWith('00:01'));
 
     setTestResults(results);
-    // eslint-disable-next-line no-console
     console.table(results.map(r=>({ test: r.name, pass: r.pass })));
   }, []);
 
@@ -378,8 +377,6 @@ export default function App(){
         </section>
       </main>
 
-      {/* Tailwind CDN */}
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" />
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,10 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+/* Minimal global styles for responsive layout */
+html, body, #root {
+  height: 100%;
 }
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
## Summary
- refine global stylesheet and viewport metadata for better mobile responsiveness
- streamline Tailwind loading and clean error handling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a03ffeb5588322ad5d7dc81e966c40